### PR TITLE
enable aarch64 target, remove allocator feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,31 @@ branches:
 
 language: rust
 
+rust:
+# build nightly only for the time beeing
+  - nightly
+
 matrix:
   fast_finish: true
-
   include:
-    - rust: nightly
+    - name: "build 64Bit"
+      install:
+        - sudo apt-get install gcc-aarch64-linux-gnu gcc-aarch64-linux-gnu
+        - cargo install cargo-xbuild
+        - rustup target add aarch64-unknown-linux-gnu
+        - rustup component add rust-src
+        - sudo chmod ugo+x build.sh
+      script: sed -i 's/path.*=.*\".*", version/version/g' Cargo.toml && ./build.sh 64 travis
 
-script: ./travis-build.sh
+    - name: "build 32Bit"
+      install:
+        - sudo apt-get install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
+        - cargo install cargo-xbuild
+        - rustup target add armv7-unknown-linux-gnueabihf
+        - rustup component add rust-src
+        - sudo chmod ugo+x build.sh
+      # remove the path in the dependencies of the cargo file to ensure we use the version from crates.io
+      script: sed -i 's/path.*=.*\".*", version/version/g' Cargo.toml && ./build.sh 32 travis
 
-install:
-# install cross compiler toolchain
-  - sudo apt-get install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
-# install cargo xbuild to proper cross compile  
-  - cargo install cargo-xbuild
-# add the build target used for Raspbarry Pi targeting builds
-  - rustup target add armv7-unknown-linux-gnueabihf
-  - rustup component add rust-src
-  - sudo chmod ugo+x ./travis-build.sh
+    - name: "unit tests"
+      script: sed -i 's/path.*=.*\".*", version/version/g' Cargo.toml && cargo test --tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "ruspiro-console"
 authors = ["André Borrmann <pspwizard@gmx.de>"]
-version = "0.2.2" # remember to update html_root_url
+version = "0.3.0" # remember to update html_root_url
 description = """
 Lightweight console abstraction to print strings to an output channel that could be easely configured/attached.
 """
 license = "Apache-2.0"
-repository = "https://github.com/RusPiRo/ruspiro-console/"
-documentation = "https://docs.rs/ruspiro-console/0.2.2"
+repository = "https://github.com/RusPiRo/ruspiro-console/tree/v0.3.0"
+documentation = "https://docs.rs/ruspiro-console/0.3.0"
 readme = "README.md"
 keywords = ["RusPiRo", "console", "raspberrypi", "baremetal"]
 categories = ["no-std", "embedded"]
@@ -20,12 +20,6 @@ maintenance = { status = "actively-developed" }
 [lib]
 
 [dependencies]
-ruspiro-singleton = "0.2"
-ruspiro-allocator = { version = "0.2", optional = true }
+ruspiro-singleton = { path = "../singleton", version = "0.3" }
 
 [features]
-with_allocator = ["ruspiro-allocator"]
-
-[package.metadata.docs.rs]
-all-features = false
-no-default-features = true

--- a/README.md
+++ b/README.md
@@ -11,23 +11,15 @@ message that shall be printed. Those are ``info!``, ``warn!`` and ``error!``.
 [![License](https://img.shields.io/crates/l/ruspiro-console.svg)](https://github.com/RusPiRo/ruspiro-console#license)
 
 ## Dependencies
-As this crate uses macros to provide formatted strings it depends on the alloc crate. When using this crate
-therefore a heap memory allocator has to be provided to successfully build and link. This could be a custom baremetal
-allocator as provided with the corresponding crate ``ruspiro_allocator``.
+This crate uses macros to provide formatted strings. This formatting requires a memory allocator to
+be present (as part of the ``alloc`` crate). So when using this crate provide an allocator such as 
+``ruspiro_allocator``.
 
 ## Usage
 To use the crate just add the following dependency to your ``Cargo.toml`` file:
 ```
 [dependencies]
 ruspiro-console = "0.3"
-```
-
-As the console crate refers to functions and structures of the ``core::alloc`` crate the final binary need to be linked
-with a custom allocator. However, the ``ruspiro-console`` can bring the RusPiRo specific allocator if you activate the
-feature ``with_allocator`` like so:
-```
-[dependencies]
-ruspiro-console = { version = "0.3", features = ["with_allocator"] }
 ```
 
 Once the console crate is available the common macros used to output strings ``print!`` and ``println`` could be used.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ allocator as provided with the corresponding crate ``ruspiro_allocator``.
 To use the crate just add the following dependency to your ``Cargo.toml`` file:
 ```
 [dependencies]
-ruspiro-console = "0.2"
+ruspiro-console = "0.3"
 ```
 
 As the console crate refers to functions and structures of the ``core::alloc`` crate the final binary need to be linked
@@ -27,7 +27,7 @@ with a custom allocator. However, the ``ruspiro-console`` can bring the RusPiRo 
 feature ``with_allocator`` like so:
 ```
 [dependencies]
-ruspiro-console = { version = "0.2", features = ["with_allocator"] }
+ruspiro-console = { version = "0.3", features = ["with_allocator"] }
 ```
 
 Once the console crate is available the common macros used to output strings ``print!`` and ``println`` could be used.

--- a/Xargo.toml
+++ b/Xargo.toml
@@ -1,4 +1,0 @@
-# define specific additional dependencies in addition to the rust core crate when running xargo to create documentation
-# the release build done with cargo xbuild does not need this to properly compile and link all used additional crates
-[target.armv7-unknown-linux-gnueabihf.dependencies]
-alloc = {}

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+set +ev
+
+if [ $# -eq 0 ] 
+    then 
+        echo "not enough parameter given"
+        exit 1
+fi
+
+# check which aarch version to build
+if [ $1 = "64" ]
+    then
+        # aarch64
+        export CFLAGS='-march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53'
+        export RUSTFLAGS='-C linker=aarch64-elf-gcc -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+neon -C link-arg=-nostartfiles -C opt-level=3 -C debuginfo=0'
+        if [ "$2" = "" ]
+            then
+                export CC='aarch64-elf-gcc'
+                export AR='aarch64-elf-ar'
+        fi
+        cargo xbuild --target aarch64-unknown-linux-gnu --release
+elif [ $1 = "32" ]
+    then
+        # aarch32
+        export CFLAGS='-mfpu=neon-fp-armv8 -mfloat-abi=hard -march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53'
+        export RUSTFLAGS='-C linker=arm-eabi-gcc.exe -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+v8,+vfp3,+d16,+thumb2,+neon -C link-arg=-nostartfiles -C opt-level=3 -C debuginfo=0'
+        if [ -z "$2" ]
+            then
+                export CC='arm-eabi-gcc.exe'
+                export AR='arm-eabi-ar.exe'
+        fi
+        cargo xbuild --target armv7-unknown-linux-gnueabihf --release
+else
+    echo 'provide the archtitecture to be build. Use either "build.sh 32" or "build.sh 64"'
+fi

--- a/makefile
+++ b/makefile
@@ -7,29 +7,29 @@
 # Author: André Borrmann 
 # License: Apache License 2.0
 #******************************************************************
-CARGO_BIN = "$(USER_ROOT)\\.cargo\\bin"
-ARM_GCC_BIN = "$(USER_ROOT)\\arm-gcc\\gcc-arm-eabi\\bin"
-ARM_GCC_LIB = "$(USER_ROOT)\\arm-gcc\\gcc-arm-eabi\\lib\\gcc\\arm-eabi\\8.3.0"
-TARGET = armv7-unknown-linux-gnueabihf
-TARGETDIR = target\\armv7-unknown-linux-gnueabihf\\release
-# environment variables needed by cargo xbuild to use the custom build target
-export CC = arm-eabi-gcc.exe
-export AR = arm-eabi-ar.exe
-export CFLAGS = -std=c11 -mfpu=neon-fp-armv8 -mfloat-abi=hard -march=armv8-a -Wall -O3 -nostartfiles -ffreestanding -mtune=cortex-a53
-export PATH +=  "$(PROJECT_ROOT);$(ARM_GCC_BIN);$(ARM_GCC_LIB);$(CARGO_BIN)"
 
-# build the current crate
-all:  
-# update dependend crates to their latest version if any
-	cargo update
-# cross compile the crate
-	cargo xbuild --lib --target $(TARGET) --release
 
+all32: export CFLAGS = -mfpu=neon-fp-armv8 -mfloat-abi=hard -march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53
+all32: export RUSTFLAGS = -C linker=arm-eabi-gcc.exe -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+v8,+vfp3,+d16,+thumb2,+neon -C link-arg=-nostartfiles -C opt-level=3 -C debuginfo=0
+all32: export CC = arm-eabi-gcc.exe
+all32: export AR = arm-eabi-ar.exe
+all32: 
+	cargo xbuild --target armv7-unknown-linux-gnueabihf --release
+
+all64: export CFLAGS = -march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53
+all64: export RUSTFLAGS = -C linker=aarch64-elf-gcc.exe -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+neon -C link-arg=-nostartfiles -C opt-level=3 -C debuginfo=0
+all64: export CC = aarch64-elf-gcc.exe
+all64: export AR = aarch64-elf-ar.exe
+all64:
+	cargo xbuild --target aarch64-unknown-linux-gnu --release
+
+doc: export CFLAGS = -march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53
+doc: export RUSTFLAGS = -C linker=aarch64-elf-gcc.exe -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+neon -C link-arg=-nostartfiles -C opt-level=3 -C debuginfo=0
+doc: export CC = aarch64-elf-gcc.exe
+doc: export AR = aarch64-elf-ar.exe
 doc:
-	# update dependend crates to their latest version if any
-	cargo update
 	# build docu for this crate using custom target
-	xargo doc --lib --no-deps --target $(TARGET) --release --open
-
+	cargo doc --no-deps --target aarch64-unknown-linux-gnu --release --open
+	
 clean:
 	cargo clean

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,98 +1,66 @@
-/*********************************************************************************************************************** 
+/***********************************************************************************************************************
  * Copyright (c) 2019 by the authors
- * 
- * Author: André Borrmann 
+ *
+ * Author: André Borrmann
  * License: Appache License 2.0
  **********************************************************************************************************************/
-#![doc(html_root_url = "https://docs.rs/ruspiro-console/0.2.2")]
+#![doc(html_root_url = "https://docs.rs/ruspiro-console/0.3.0")]
 #![no_std]
 
 //! # Console abstraction
-//! 
+//!
 //! This crate provides a console abstraction to enable string output to a configurable output channel.
-//! It also provides the convinient macros (``print!`` and ``println!``) to output text that are usually not 
-//! available in ``[no_std]`` environments. However this crate also provide macros to indicate the severity of the 
+//! It also provides the convinient macros (``print!`` and ``println!``) to output text that are usually not
+//! available in ``[no_std]`` environments. However this crate also provide macros to indicate the severity of the
 //! message that shall be printed. Those are ``info!``, ``warn!`` and ``error!``.
-//! 
+//!
 //! # Dependencies
-//! As this crate uses macros to provide formatted strings it depends on the alloc crate. When using this crate
-//! therefore a heap memory allocator has to be provided to successfully build and link. This could be a custom baremetal
-//! allocator as provided with the corresponding crate ``ruspiro_allocator``.
-//! 
-//! # Usage
-//! 
-//! As the console crate refers to functions and structures of the ``core::alloc`` crate the final binary need to be linked
-//! with a custom allocator. However, the ``ruspiro-console`` can bring the RusPiRo specific allocator if you activate the
-//! feature ``with_allocator`` like so:
-//! ```
-//! [dependencies]
-//! ruspiro-console = { version = "0.2", features = ["with_allocator"] }
-//! ```
-//! 
+//! As this crate uses macros to provide formatted strings it depends on the alloc crate. Therefore
+//! a heap memory allocator has to be provided to successfully build and link. This could be a custom baremetal
+//! allocator as provided with the corresponding crate ``ruspiro_allocator`` or any other.
+//!
+//! # Example
 //! To actually set an active output channel you need to provide a structure that implements the ``ConsoleImpl`` trait. This
-//! for excample is done in the Uart like so:
+//! for example is done in the Uart like so:
 //! ```
 //! impl ConsoleImpl for Uart1 {
 //!     fn putc(&self, c: char) {
 //!         self.send_char(c);
 //!     }
-//! 
+//!
 //!     fn puts(&self, s: &str) {
 //!         self.send_string(s);
 //!     }
 //! }
 //! ```
-//! 
+//!
 //! If this trait has been implemented this structure can be used as actual console. To use it there should be the following
 //! code written at the earliest possible point in the main crate of the binary (e.g. the kernel)
 //! ```
 //! use ruspiro_console::*;
 //! use ruspiro_uart::*; // as we demonstrate with the Uart.
-//! 
-//! fn demo() {
+//!
+//! fn main() {
 //!     let mut uart = Uart1::new(); // create a new uart struct
 //!     if uart.initialize(250_000_000, 115_200).is_ok() { // initialize the Uart with fixed core rate and baud rate
 //!         CONSOLE.take_for(|cons| cons.replace(uart)); // from this point CONSOLE takes ownership of Uart
 //!         // uncommenting the following line will give compiler error as uart is moved
 //!         // uart.send_string("I'm assigned to a console");
 //!     }
-//! 
+//!
 //!     // if everything went fine uart should be assigned to the console for generic output
 //!     println!("Console is ready and display's through uart");
 //! }
 //! ```
-//! # Features
-//! 
-//! - ``with_allocator`` this will bring the ``ruspiro-allocator`` which is usefull if you don't want to provide your own
-//! when using this crate.
-
 
 pub extern crate alloc;
-
-#[cfg(feature = "with_allocator")]
-extern crate ruspiro_allocator;
-
-/**
- * when this crate shall use the ruspiro-allocator crate this should usually just
- * provide the rust_oom function. However, this seem to be optimized away at some point
- * therefore use this "hack" to define an extern existence of this function and do a
- * dummy call to it to ensure the function will some sort of "re-exported" by this crate...
- * hack, but works...
- */
-#[cfg(feature = "with_allocator")]
-extern { fn rust_oom(); }
-
-#[cfg(feature = "with_allocator")]
-#[no_mangle]
-fn use_rust_oom() { unsafe { rust_oom(); } }
-
 
 #[macro_use]
 pub mod macros;
 pub use macros::*;
 
-use ruspiro_singleton::Singleton;
 use alloc::boxed::Box;
+use ruspiro_singleton::Singleton;
 
 /// Every "real" console need to implement this trait. Also the explicit Drop trait need to be implemented
 /// as the drop method of the implementing console will be called as soon as the actual console does release
@@ -105,19 +73,17 @@ pub trait ConsoleImpl: Drop {
 }
 
 /// The Console singleton used by print! and println! macros
-pub static CONSOLE: Singleton<Console> = Singleton::<Console>::new(
-        Console { 
-            current: None,
-            default: DefaultConsole {}
-        }
-    );
+pub static CONSOLE: Singleton<Console> = Singleton::<Console>::new(Console {
+    current: None,
+    default: DefaultConsole {},
+});
 
 /// The base printing function hidden behind the print! and println! macro. This function fowards all calls to the
 /// generic console which puts the string to the assigned output channel.
 pub fn print(s: &str) {
     // pass the string to the actual configured console to be printed
-    CONSOLE.take_for(|console| {        
-        console.get_current().puts(s);        
+    CONSOLE.take_for(|console| {
+        console.get_current().puts(s);
     });
 }
 
@@ -128,7 +94,7 @@ pub struct Console {
 }
 
 impl Console {
-    /// Retrieve the current active console to be used for passing strings to to get printend somewhere 
+    /// Retrieve the current active console to be used for passing strings to to get printend somewhere
     pub fn get_current(&self) -> &dyn ConsoleImpl {
         if let Some(ref console) = self.current {
             console.as_ref()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,9 @@
 //! message that shall be printed. Those are ``info!``, ``warn!`` and ``error!``.
 //!
 //! # Dependencies
-//! As this crate uses macros to provide formatted strings it depends on the alloc crate. Therefore
-//! a heap memory allocator has to be provided to successfully build and link. This could be a custom baremetal
-//! allocator as provided with the corresponding crate ``ruspiro_allocator`` or any other.
+//! This crate uses macros to provide formatted strings. This formatting requires a memory allocator to
+//! be present (as part of the ``alloc`` crate). So when using this crate provide an allocator such as
+//! ``ruspiro_allocator``.
 //!
 //! # Example
 //! To actually set an active output channel you need to provide a structure that implements the ``ConsoleImpl`` trait. This
@@ -111,7 +111,7 @@ impl Console {
     }
 }
 
-// The default console is a kind of fall back that prints nothing...
+/// The default console is a kind of fall back that prints nothing...
 struct DefaultConsole;
 
 impl ConsoleImpl for DefaultConsole {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,12 +1,12 @@
-/*********************************************************************************************************************** 
+/***********************************************************************************************************************
  * Copyright (c) 2019 by the authors
- * 
- * Author: André Borrmann 
+ *
+ * Author: André Borrmann
  * License: Appache License 2.0
  **********************************************************************************************************************/
 
 //! # Convinient output macros to print formatted strings to the configured channel of the console
-//! 
+//!
 //! Provide the print!() and println!() macro's as used in the libstd crate which is not available here
 //! as we do need formatting on the parameter and formatting requires memory allocation the
 //! use of this functions is only possible if a global allocator is implemented.<br>

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-set -ev
-
-export CFLAGS='-mfpu=neon-fp-armv8 -mfloat-abi=hard -march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53'
-export RUSTFLAGS='-C linker=arm-linux-gnueabihf-gcc -C target-cpu=cortex-a53 -C target-feature=+a53,+fp-armv8,+v8,+vfp3,+d16,+thumb2,+neon -C link-arg=-nostartfiles -C opt-level=3 -C debuginfo=0'
-
-cargo xbuild --target armv7-unknown-linux-gnueabihf --verbose --release --all


### PR DESCRIPTION
provide aarch64 build target architecture
remove the "with_allocator" feature which uses the ruspiro_allocator under the hood. This now requires any user of this crate to explicitly provide an allocator, when building a binary and linking. However, this still could be the ruspiro one but it's no longer nested this deep in the dependencies which was sometimes not obvious and added unnecessary complexity to this crate