### PR TITLE
Adjust the stored Writer to require Send + Sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## :peach: v0.4.1
+
+- ### :detective: Fixes
+
+  - require the actual structure to be used as `Console` to implement `Send` and `Sync` as this is a requirement of the `Singleton` now.
+  
 ## :peach: v0.4.0
 
 - ### :wrench: Maintenance

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruspiro-console"
 authors = ["André Borrmann <pspwizard@gmx.de>"]
-version = "0.4.0" # remember to update html_root_url
+version = "0.4.1" # remember to update html_root_url
 description = """
 Lightweight console abstraction for bare metal implementations to print strings to an output channel that could be easely configured/attached.
 """
@@ -20,7 +20,7 @@ maintenance = { status = "actively-developed" }
 [lib]
 
 [dependencies]
-ruspiro-singleton = "0.4.0"
+ruspiro-singleton = "0.4.1"
 
 [features]
 ruspiro_pi3 = []

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ fn demo() {
 }
 ```
 
-> ! HINT!
+> !HINT!
 > As the `Write` trait requires the structure to be mutable when writing to the output channel the console operations are blocking operations -> thus requiring atomic operations to be possible -> thus requiring the *MMU* to be activated before using the console abstraction is possible. Otherwise execution will *hang* as atomics are not able to be processed by the CPU.
 
 ## License


### PR DESCRIPTION
The `Singleton` that wraps the `Console` requires the inner structure to be `Send` and `Sync`. So also add the requirement to the `Writer` that will be stored inside the `Console`.